### PR TITLE
Add company name extractions

### DIFF
--- a/docs/stix-mapping.md
+++ b/docs/stix-mapping.md
@@ -1522,6 +1522,7 @@ UUIDv5 is generated using namespace `f92e15d9-6afc-5ae2-bb3e-85a1fd83a3b5` and `
 Objects created:
 
 * `identity`
+* `sector`
 
 ```json
 {
@@ -1541,22 +1542,6 @@ Objects created:
 ```
 
 UUIDv5 is generated using namespace `f92e15d9-6afc-5ae2-bb3e-85a1fd83a3b5` and `txt2stix+<extracted_value>`
-
-### stix-mapping: `software` (product)
-
-Objects created:
-
-* `software`
-
-```json
-{
-    "type": "software",
-    "spec_version": "2.1",
-    "id": "software--<STIX2 LIB GEN>",
-    "name": "<EXTRACTED VALUE>",
-    "vendor": "<EXTRACTED VALUE>"
-}
-```
 
 ## STIX Mapping (remotely created objects)
 

--- a/docs/stix-mapping.md
+++ b/docs/stix-mapping.md
@@ -1241,7 +1241,6 @@ To ensure duplicate `phone-number` objects are not created for the same values, 
 * Namespace = `00abedb4-aa42-466c-9c01-fed23315a9b7` (this is the default MITRE namespace used in the stix2 python lib https://github.com/oasis-open/cti-python-stix2/blob/50fd81fd6ba4f26824a864319305bc298e89bb45/stix2/base.py#L29)
 * Value = `<number>`
 
-
 ### stix-mapping: `process`
 
 Objects always created:
@@ -1295,7 +1294,6 @@ To ensure duplicate `process` objects are not created for the same values, a UUI
 
 * Namespace = `00abedb4-aa42-466c-9c01-fed23315a9b7` (this is the default MITRE namespace used in the stix2 python lib https://github.com/oasis-open/cti-python-stix2/blob/50fd81fd6ba4f26824a864319305bc298e89bb45/stix2/base.py#L29)
 * Value = `<number>`
-
 
 ### stix-mapping: `attack-pattern`
 
@@ -1518,6 +1516,47 @@ Objects created:
 ```
 
 UUIDv5 is generated using namespace `f92e15d9-6afc-5ae2-bb3e-85a1fd83a3b5` and `txt2stix+<extracted_value>`
+
+### stix-mapping: `identity` (companies)
+
+Objects created:
+
+* `identity`
+
+```json
+{
+    "type": "identity",
+    "spec_version": "2.1",
+    "id": "identity--<UUIDV5>",
+    "created_by_ref": "identity--<TXT2STIX IDENTITY>",
+    "created": "2020-01-01T00:00:00.000Z",
+    "modified": "2020-01-01T00:00:00.000Z",
+    "name": "<EXTRACTED VALUE>",
+    "identity_class": "organization",
+    "object_marking_refs": [
+        "marking-definition--94868c89-83c2-464b-929b-a1a8aa3c8487",
+        "marking-definition--f92e15d9-6afc-5ae2-bb3e-85a1fd83a3b5"
+    ]
+}
+```
+
+UUIDv5 is generated using namespace `f92e15d9-6afc-5ae2-bb3e-85a1fd83a3b5` and `txt2stix+<extracted_value>`
+
+### stix-mapping: `software` (product)
+
+Objects created:
+
+* `software`
+
+```json
+{
+    "type": "software",
+    "spec_version": "2.1",
+    "id": "software--<STIX2 LIB GEN>",
+    "name": "<EXTRACTED VALUE>",
+    "vendor": "<EXTRACTED VALUE>"
+}
+```
 
 ## STIX Mapping (remotely created objects)
 

--- a/includes/extractions/ai/config.yaml
+++ b/includes/extractions/ai/config.yaml
@@ -1002,6 +1002,24 @@ ai_sector:
   test_cases: ai_sector_names
   stix_mapping: ctibutler-sector-name
 
+####### Identity (companies) #######
+
+ai_company_names:
+  type: ai
+  dogesec_web: true
+  name: 'Companies'
+  description: 'Will extract all company names'
+  notes: ''
+  created: 2020-01-01
+  modified:  2020-01-01
+  created_by: dogesec
+  version: 1.0.0
+  prompt_base: 'Extract all company names from the text.'
+  prompt_helper: ''
+  prompt_conversion: ''
+  test_cases: ai_company_names
+  stix_mapping: company-names
+
 ####### Generic Extractions #######
 
 ai_attack_pattern:

--- a/includes/extractions/ai/config.yaml
+++ b/includes/extractions/ai/config.yaml
@@ -1018,7 +1018,7 @@ ai_company_names:
   prompt_helper: ''
   prompt_conversion: ''
   test_cases: ai_company_names
-  stix_mapping: company-names
+  stix_mapping: identity-company-name
 
 ####### Generic Extractions #######
 

--- a/includes/tests/test_cases.yaml
+++ b/includes/tests/test_cases.yaml
@@ -709,10 +709,18 @@ ai_mitre_d3fend:
 ####### Sector ########
 generic_sector_aliases:
   test_positive_examples:
-    - Biotechnology
-    - Diplomatic Organizations
+    - 'Biotechnology'
+    - 'Diplomatic Organizations'
   test_negative_examples:
-    - Random Company Inc
+    - 'Random Company Inc'
+
+####### Sector ########
+generic_company_names:
+  test_positive_examples:
+    - 'Google'
+    - 'Microsoft'
+  test_negative_examples:
+    - Biotechnology
 
 ####### Misc STIX Objects #######
 

--- a/tests/data/extraction_types/ai_mitre_d3fend.txt
+++ b/tests/data/extraction_types/ai_mitre_d3fend.txt
@@ -1,6 +1,6 @@
 ====Good====
 
-3f:Isolate
+d3f:Isolate
 
 ====Bad====
 

--- a/tests/data/extraction_types/all_cases.txt
+++ b/tests/data/extraction_types/all_cases.txt
@@ -180,9 +180,11 @@ D3-SPP
 d3f:Isolate
 DNS Denylisting
 User Account Permissions
-3f:Isolate
+d3f:Isolate
 Biotechnology
 Diplomatic Organizations
+Google
+Microsoft
 Content Spoofer
 Inspector-1
 Patch server

--- a/tests/data/extraction_types/generic_company_names.txt
+++ b/tests/data/extraction_types/generic_company_names.txt
@@ -1,0 +1,8 @@
+====Good====
+
+Google
+Microsoft
+
+====Bad====
+
+Biotechnology

--- a/tests/data/manually_generated_reports/ai_generated/company.txt
+++ b/tests/data/manually_generated_reports/ai_generated/company.txt
@@ -1,0 +1,18 @@
+On 14 July 2026, an unidentified individual gained
+unauthorized physical access to **Northbridge Industrial
+Systems** by tailgating an employee through a secure
+entrance.
+
+The intruder briefly accessed an unattended workstation
+and connected an unauthorized USB device before leaving
+unnoticed.
+
+Three days later, the company detected unauthorized
+account access and attempted data exfiltration,
+consistent with malware deployed during the physical
+breach.
+
+Investigators are also examining possible links to a
+recent attack against **SilverPeak Logistics**,
+suggesting the two incidents may be part of a broader
+campaign targeting regional businesses.

--- a/tests/manual-tests/cases-extraction-type-ai.md
+++ b/tests/manual-tests/cases-extraction-type-ai.md
@@ -890,6 +890,21 @@ python3 txt2stix.py \
 	--report_id d8c1b8fa-4d82-488f-932f-ee987a556107
 ```
 
+#### ai_companies
+
+```shell
+python3 txt2stix.py \
+	--relationship_mode standard \
+	--input_file tests/data/extraction_types/generic_sector_aliases.txt \
+	--name 'ai_company_names' \
+	--tlp_level clear \
+	--confidence 100 \
+	--use_extractions ai_company_names \
+	--ai_settings_extractions openai:gpt-5-mini \
+	--report_id 2567570b-0315-4856-a401-5e1f881d28da
+```
+
+
 ## Generic STIX lookups
 
 #### ai_attack_pattern

--- a/tests/src/test_retriever.py
+++ b/tests/src/test_retriever.py
@@ -110,7 +110,7 @@ def f():
         (
             "ctibutler-mitre-atlas-name",
             "Defense Evasion",
-            ["x-mitre-tactic--22a483dc-1102-5fd0-94bd-b4259c537274"],
+            ["x-mitre-tactic--22a483dc-1102-5fd0-94bd-b4259c537274", "attack-pattern--1f612544-c939-5d60-ad34-2d0644622e1f"],
         ),
         (
             "ctibutler-disarm-id",

--- a/txt2stix/indicator.py
+++ b/txt2stix/indicator.py
@@ -861,7 +861,10 @@ def _build_observables(
             )
         ]
 
-    if stix_mapping == "identity":
+    if stix_mapping.startswith("identity"):
+        _class = "unspecified"
+        if stix_mapping == "identity-company-name":
+            _class = "organization"
         stix_objects = [
             dict_to_stix2(
                 {
@@ -872,7 +875,7 @@ def _build_observables(
                     "modified": _date,
                     "id": "identity--" + _id_part,
                     "name": extracted_value,
-                    "identity_class": "unspecified",
+                    "identity_class": _class,
                     "external_references": external_refs,
                     "object_marking_refs": marking_refs,
                 }


### PR DESCRIPTION
closes #304 

This pull request adds support for extracting company names as `identity` objects (with `identity_class: organization`) from AI-generated reports, updates the STIX mapping documentation and logic to handle this new extraction, and introduces a test case for company name extraction. The changes also include minor documentation cleanups and a more flexible STIX mapping for `identity` objects.

**New extraction and STIX mapping for company names:**

* Added an AI extraction configuration for company names (`ai_company_names`) in `includes/extractions/ai/config.yaml`, mapping to the new `identity-company-name` STIX mapping.
* Updated the STIX mapping documentation in `docs/stix-mapping.md` to document the new `identity` (companies) mapping and the associated STIX object structure.

**STIX object generation logic:**

* Modified `_build_observables` in `txt2stix/indicator.py` to handle STIX mappings starting with `identity`, and to set the `identity_class` to `organization` for the new `identity-company-name` mapping. [[1]](diffhunk://#diff-12a46c66d8b4dfee77d87d9f34f028fe1d5bf775184490b071eb683dfaea9d1fL864-R867) [[2]](diffhunk://#diff-12a46c66d8b4dfee77d87d9f34f028fe1d5bf775184490b071eb683dfaea9d1fL875-R878)

**Testing:**

* Added a new test report (`company.txt`) with sample text mentioning company names to support and verify the new extraction.

**Documentation cleanups:**

* Removed unnecessary blank lines in `docs/stix-mapping.md` for better readability. [[1]](diffhunk://#diff-56c6ac0fd78ce8c287df0877031416a8fae195dea1d51b1b747bf8e8821b3aebL1244) [[2]](diffhunk://#diff-56c6ac0fd78ce8c287df0877031416a8fae195dea1d51b1b747bf8e8821b3aebL1299)